### PR TITLE
add travis.yml to run ci jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+    - curl -s http://getcomposer.org/installer | php
+    - php composer.phar install --dev
+
+script:
+    - phpunit


### PR DESCRIPTION
In order to avoid regression bugs and guarantee a high level of code-quality, we have to run UnitTests, etc. after every push.

This project must be registered at travis-ci.org to close this PR.
